### PR TITLE
updated JME HLT thresholds for cms-sw#32903

### DIFF
--- a/HLTrigger/Phase2/python/HLT_75e33.py
+++ b/HLTrigger/Phase2/python/HLT_75e33.py
@@ -561,24 +561,24 @@ process.load("HLT_75e33/modules/hltPFPuppiCentralJetQuad30MaxEta2p4_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiCentralJetsQuad30HT200MaxEta2p4_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiCentralJetsQuad30HT330MaxEta2p4_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiHT_cfi")
-process.load("HLT_75e33/modules/hltPFPuppiHT1050_cfi")
+process.load("HLT_75e33/modules/hltPFPuppiHT1070_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiJetForBtagEta2p4_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiJetForBtagEta4p0_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiJetForBtagSelectorEta2p4_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiJetForBtagSelectorEta4p0_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiMET_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiMETTypeOne_cfi")
-process.load("HLT_75e33/modules/hltPFPuppiMETTypeOne120_cfi")
+process.load("HLT_75e33/modules/hltPFPuppiMETTypeOne140_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiMETTypeOneCorrector_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiMETv0_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiMHT_cfi")
-process.load("HLT_75e33/modules/hltPFPuppiMHT120_cfi")
+process.load("HLT_75e33/modules/hltPFPuppiMHT140_cfi")
 process.load("HLT_75e33/modules/hltPFPuppiNoLep_cfi")
 process.load("HLT_75e33/modules/hltPFSoftKillerMET_cfi")
 process.load("HLT_75e33/modules/hltPixelClustersMultiplicity_cfi")
 process.load("HLT_75e33/modules/hltPrimaryVertexAssociation_cfi")
 process.load("HLT_75e33/modules/hltPrimaryVertexAssociationModEta2p4_cfi")
-process.load("HLT_75e33/modules/hltSingleAK4PFPuppiJet500_cfi")
+process.load("HLT_75e33/modules/hltSingleAK4PFPuppiJet520_cfi")
 process.load("HLT_75e33/modules/horeco_cfi")
 process.load("HLT_75e33/modules/hybridSuperClusters_cfi")
 process.load("HLT_75e33/modules/inclusiveSecondaryVertices_cfi")
@@ -731,15 +731,15 @@ process.load("HLT_75e33/modules/uncleanedOnlyMulti5x5SuperClustersWithPreshower_
 process.load("HLT_75e33/modules/unsortedOfflinePrimaryVertices_cfi")
 process.load("HLT_75e33/modules/vertexMerger_cfi")
 process.load("HLT_75e33/modules/zdcreco_cfi")
-process.load("HLT_75e33/paths/HLT_AK4PFPuppiJet500_cfi")
+process.load("HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
 process.load("HLT_75e33/paths/HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4_v1_cfi")
 process.load("HLT_75e33/paths/HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4_v1_cfi")
 process.load("HLT_75e33/paths/HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepCSV_2p4_v1_cfi")
 process.load("HLT_75e33/paths/HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4_v1_cfi")
 process.load("HLT_75e33/paths/HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4_v1_cfi")
 process.load("HLT_75e33/paths/HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4_v1_cfi")
-process.load("HLT_75e33/paths/HLT_PFPuppiHT1050_cfi")
-process.load("HLT_75e33/paths/HLT_PFPuppiMETTypeOne120_PFPuppiMHT120_cfi")
+process.load("HLT_75e33/paths/HLT_PFPuppiHT1070_cfi")
+process.load("HLT_75e33/paths/HLT_PFPuppiMETTypeOne140_PFPuppiMHT140_cfi")
 process.load("HLT_75e33/paths/HLTObjects_cfi")
 process.load("HLT_75e33/paths/L1_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_p71_2p4_v1_cfi")
 process.load("HLT_75e33/paths/L1_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4_v1_cfi")
@@ -1345,9 +1345,9 @@ process.schedule = cms.Schedule(*[
     process.L1T_PFPuppiMET220off,
 
     # Jets/MET HLT paths
-    process.HLT_AK4PFPuppiJet500,
-    process.HLT_PFPuppiHT1050,
-    process.HLT_PFPuppiMETTypeOne120_PFPuppiMHT120,
+    process.HLT_AK4PFPuppiJet520,
+    process.HLT_PFPuppiHT1070,
+    process.HLT_PFPuppiMETTypeOne140_PFPuppiMHT140,
 
     # L1T and HLT objects used by b-tagging
     process.L1Objects,

--- a/HLTrigger/Phase2/python/HLT_75e33/modules/hltPFPuppiHT1070_cfi.py
+++ b/HLTrigger/Phase2/python/HLT_75e33/modules/hltPFPuppiHT1070_cfi.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-hltPFPuppiHT1050 = cms.EDFilter("HLTHtMhtFilter",
+hltPFPuppiHT1070 = cms.EDFilter("HLTHtMhtFilter",
     htLabels = cms.VInputTag("hltPFPuppiHT"),
     meffSlope = cms.vdouble(1.0),
     mhtLabels = cms.VInputTag("hltPFPuppiHT"),
-    minHt = cms.vdouble(1050.0),
+    minHt = cms.vdouble(1070.0),
     minMeff = cms.vdouble(0.0),
     minMht = cms.vdouble(0.0),
     saveTags = cms.bool(True)

--- a/HLTrigger/Phase2/python/HLT_75e33/modules/hltPFPuppiMETTypeOne140_cfi.py
+++ b/HLTrigger/Phase2/python/HLT_75e33/modules/hltPFPuppiMETTypeOne140_cfi.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-hltPFPuppiMETTypeOne120 = cms.EDFilter("HLT1PFMET",
+hltPFPuppiMETTypeOne140 = cms.EDFilter("HLT1PFMET",
     MaxEta = cms.double(-1.0),
     MaxMass = cms.double(-1.0),
     MinE = cms.double(-1.0),
     MinEta = cms.double(-1.0),
     MinMass = cms.double(-1.0),
     MinN = cms.int32(1),
-    MinPt = cms.double(120.0),
+    MinPt = cms.double(140.0),
     inputTag = cms.InputTag("hltPFPuppiMETTypeOne"),
     saveTags = cms.bool(True),
     triggerType = cms.int32(87)

--- a/HLTrigger/Phase2/python/HLT_75e33/modules/hltPFPuppiMHT140_cfi.py
+++ b/HLTrigger/Phase2/python/HLT_75e33/modules/hltPFPuppiMHT140_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-hltPFPuppiMHT120 = cms.EDFilter("HLTMhtFilter",
+hltPFPuppiMHT140 = cms.EDFilter("HLTMhtFilter",
     mhtLabels = cms.VInputTag("hltPFPuppiMHT"),
-    minMht = cms.vdouble(120.0),
+    minMht = cms.vdouble(140.0),
     saveTags = cms.bool(True)
 )

--- a/HLTrigger/Phase2/python/HLT_75e33/modules/hltSingleAK4PFPuppiJet520_cfi.py
+++ b/HLTrigger/Phase2/python/HLT_75e33/modules/hltSingleAK4PFPuppiJet520_cfi.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-hltSingleAK4PFPuppiJet500 = cms.EDFilter("HLT1PFJet",
+hltSingleAK4PFPuppiJet520 = cms.EDFilter("HLT1PFJet",
     MaxEta = cms.double(5.0),
     MaxMass = cms.double(-1.0),
     MinE = cms.double(-1.0),
     MinEta = cms.double(-1.0),
     MinMass = cms.double(-1.0),
     MinN = cms.int32(1),
-    MinPt = cms.double(500.0),
+    MinPt = cms.double(520.0),
     inputTag = cms.InputTag("hltAK4PFPuppiJetsCorrected"),
     saveTags = cms.bool(True),
     triggerType = cms.int32(85)

--- a/HLTrigger/Phase2/python/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi.py
+++ b/HLTrigger/Phase2/python/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from ..modules.hltSingleAK4PFPuppiJet500_cfi import *
+from ..modules.hltSingleAK4PFPuppiJet520_cfi import *
 from ..modules.l1tSinglePFPuppiJet230off_cfi import *
 from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
 from ..sequences.HLTParticleFlowSequence_cfi import *
 
-HLT_AK4PFPuppiJet500 = cms.Path(l1tSinglePFPuppiJet230off+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltSingleAK4PFPuppiJet500)
+HLT_AK4PFPuppiJet520 = cms.Path(l1tSinglePFPuppiJet230off+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltSingleAK4PFPuppiJet520)

--- a/HLTrigger/Phase2/python/HLT_75e33/paths/HLT_PFPuppiHT1070_cfi.py
+++ b/HLTrigger/Phase2/python/HLT_75e33/paths/HLT_PFPuppiHT1070_cfi.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltPFPuppiHT_cfi import *
-from ..modules.hltPFPuppiHT1050_cfi import *
+from ..modules.hltPFPuppiHT1070_cfi import *
 from ..modules.l1tPFPuppiHT_cfi import *
 from ..modules.l1tPFPuppiHT450off_cfi import *
 from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
 from ..sequences.HLTParticleFlowSequence_cfi import *
 
-HLT_PFPuppiHT1050 = cms.Path(l1tPFPuppiHT+l1tPFPuppiHT450off+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltPFPuppiHT+hltPFPuppiHT1050)
+HLT_PFPuppiHT1070 = cms.Path(l1tPFPuppiHT+l1tPFPuppiHT450off+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+hltPFPuppiHT+hltPFPuppiHT1070)

--- a/HLTrigger/Phase2/python/HLT_75e33/paths/HLT_PFPuppiMETTypeOne140_PFPuppiMHT140_cfi.py
+++ b/HLTrigger/Phase2/python/HLT_75e33/paths/HLT_PFPuppiMETTypeOne140_PFPuppiMHT140_cfi.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltPFPuppiMETTypeOne_cfi import *
-from ..modules.hltPFPuppiMETTypeOne120_cfi import *
+from ..modules.hltPFPuppiMETTypeOne140_cfi import *
 from ..modules.hltPFPuppiMETTypeOneCorrector_cfi import *
 from ..modules.hltPFPuppiMHT_cfi import *
-from ..modules.hltPFPuppiMHT120_cfi import *
+from ..modules.hltPFPuppiMHT140_cfi import *
 from ..modules.l1tPFPuppiMET220off_cfi import *
 from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
 from ..sequences.HLTParticleFlowSequence_cfi import *
 from ..sequences.HLTPFPuppiMETReconstruction_cfi import *
 
-HLT_PFPuppiMETTypeOne120_PFPuppiMHT120 = cms.Path(l1tPFPuppiMET220off+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+HLTPFPuppiMETReconstruction+hltPFPuppiMETTypeOneCorrector+hltPFPuppiMETTypeOne+hltPFPuppiMETTypeOne120+hltPFPuppiMHT+hltPFPuppiMHT120)
+HLT_PFPuppiMETTypeOne140_PFPuppiMHT140 = cms.Path(l1tPFPuppiMET220off+HLTParticleFlowSequence+HLTAK4PFPuppiJetsReconstruction+HLTPFPuppiMETReconstruction+hltPFPuppiMETTypeOneCorrector+hltPFPuppiMETTypeOne+hltPFPuppiMETTypeOne140+hltPFPuppiMHT+hltPFPuppiMHT140)

--- a/HLTrigger/Phase2/python/HLT_75e33_cfg.py
+++ b/HLTrigger/Phase2/python/HLT_75e33_cfg.py
@@ -35347,11 +35347,11 @@ process.hltPFPuppiCentralJetsQuad30HT330MaxEta2p4 = cms.EDFilter("HLTHtMhtFilter
 )
 
 
-process.hltPFPuppiHT1050 = cms.EDFilter("HLTHtMhtFilter",
+process.hltPFPuppiHT1070 = cms.EDFilter("HLTHtMhtFilter",
     htLabels = cms.VInputTag("hltPFPuppiHT"),
     meffSlope = cms.vdouble(1.0),
     mhtLabels = cms.VInputTag("hltPFPuppiHT"),
-    minHt = cms.vdouble(1050.0),
+    minHt = cms.vdouble(1070.0),
     minMeff = cms.vdouble(0.0),
     minMht = cms.vdouble(0.0),
     saveTags = cms.bool(True)
@@ -35386,35 +35386,35 @@ process.hltPFPuppiJetForBtagSelectorEta4p0 = cms.EDFilter("HLT1PFJet",
 )
 
 
-process.hltPFPuppiMETTypeOne120 = cms.EDFilter("HLT1PFMET",
+process.hltPFPuppiMETTypeOne140 = cms.EDFilter("HLT1PFMET",
     MaxEta = cms.double(-1.0),
     MaxMass = cms.double(-1.0),
     MinE = cms.double(-1.0),
     MinEta = cms.double(-1.0),
     MinMass = cms.double(-1.0),
     MinN = cms.int32(1),
-    MinPt = cms.double(120.0),
+    MinPt = cms.double(140.0),
     inputTag = cms.InputTag("hltPFPuppiMETTypeOne"),
     saveTags = cms.bool(True),
     triggerType = cms.int32(87)
 )
 
 
-process.hltPFPuppiMHT120 = cms.EDFilter("HLTMhtFilter",
+process.hltPFPuppiMHT140 = cms.EDFilter("HLTMhtFilter",
     mhtLabels = cms.VInputTag("hltPFPuppiMHT"),
-    minMht = cms.vdouble(120.0),
+    minMht = cms.vdouble(140.0),
     saveTags = cms.bool(True)
 )
 
 
-process.hltSingleAK4PFPuppiJet500 = cms.EDFilter("HLT1PFJet",
+process.hltSingleAK4PFPuppiJet520 = cms.EDFilter("HLT1PFJet",
     MaxEta = cms.double(5.0),
     MaxMass = cms.double(-1.0),
     MinE = cms.double(-1.0),
     MinEta = cms.double(-1.0),
     MinMass = cms.double(-1.0),
     MinN = cms.int32(1),
-    MinPt = cms.double(500.0),
+    MinPt = cms.double(520.0),
     inputTag = cms.InputTag("hltAK4PFPuppiJetsCorrected"),
     saveTags = cms.bool(True),
     triggerType = cms.int32(85)
@@ -44606,7 +44606,7 @@ process.HLTParticleFlowSequence = cms.Sequence(process.RawToDigi+process.localre
 process.HLTJMESequence = cms.Sequence(process.HLTCaloMETReconstruction+process.HLTPFClusterJMEReconstruction+process.HLTAK4PFJetsReconstruction+process.HLTAK8PFJetsReconstruction+process.HLTPFJetsCHSReconstruction+process.HLTPFMETsReconstruction+process.HLTPFCHSMETReconstruction+process.HLTPFSoftKillerMETReconstruction+process.HLTPFPuppiJMEReconstruction)
 
 
-process.HLT_AK4PFPuppiJet500 = cms.Path(process.l1tSinglePFPuppiJet230off+process.HLTParticleFlowSequence+process.HLTAK4PFPuppiJetsReconstruction+process.hltSingleAK4PFPuppiJet500)
+process.HLT_AK4PFPuppiJet520 = cms.Path(process.l1tSinglePFPuppiJet230off+process.HLTParticleFlowSequence+process.HLTAK4PFPuppiJetsReconstruction+process.hltSingleAK4PFPuppiJet520)
 
 
 process.HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4_v1 = cms.Path(process.l1tDoublePFPuppiJet112offMaxEta2p4+process.l1tDoublePFPuppiJets128Eta2p3MaxDeta1p6+process.HLTParticleFlowSequence+process.HLTAK4PFPuppiJetsReconstruction+process.hltDoublePFPuppiJets128MaxEta2p4+process.hltDoublePFPuppiJets128Eta2p3MaxDeta1p6+process.HLTBtagDeepCSVSequencePFPuppiModEta2p4+process.hltBTagPFPuppiDeepCSV0p865DoubleEta2p4)
@@ -44627,10 +44627,10 @@ process.HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4_
 process.HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4_v1 = cms.Path(process.l1tPFPuppiHTMaxEta2p4+process.l1tPFPuppiHT400offMaxEta2p4+process.l1t1PFPuppiJet70offMaxEta2p4+process.l1t2PFPuppiJet55offMaxEta2p4+process.l1t4PFPuppiJet40offMaxEta2p4+process.l1t4PFPuppiJet25OnlineMaxEta2p4+process.HLTParticleFlowSequence+process.HLTAK4PFPuppiJetsReconstruction+process.hltPFPuppiCentralJetQuad30MaxEta2p4+process.hlt1PFPuppiCentralJet75MaxEta2p4+process.hlt2PFPuppiCentralJet60MaxEta2p4+process.hlt3PFPuppiCentralJet45MaxEta2p4+process.hlt4PFPuppiCentralJet40MaxEta2p4+process.hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4+process.hltPFPuppiCentralJetsQuad30HT330MaxEta2p4+process.HLTBtagDeepFlavourSequencePFPuppiModEta2p4+process.hltBTagPFPuppiDeepFlavour0p275Eta2p4TripleEta2p4)
 
 
-process.HLT_PFPuppiHT1050 = cms.Path(process.l1tPFPuppiHT+process.l1tPFPuppiHT450off+process.HLTParticleFlowSequence+process.HLTAK4PFPuppiJetsReconstruction+process.hltPFPuppiHT+process.hltPFPuppiHT1050)
+process.HLT_PFPuppiHT1070 = cms.Path(process.l1tPFPuppiHT+process.l1tPFPuppiHT450off+process.HLTParticleFlowSequence+process.HLTAK4PFPuppiJetsReconstruction+process.hltPFPuppiHT+process.hltPFPuppiHT1070)
 
 
-process.HLT_PFPuppiMETTypeOne120_PFPuppiMHT120 = cms.Path(process.l1tPFPuppiMET220off+process.HLTParticleFlowSequence+process.HLTAK4PFPuppiJetsReconstruction+process.HLTPFPuppiMETReconstruction+process.hltPFPuppiMETTypeOneCorrector+process.hltPFPuppiMETTypeOne+process.hltPFPuppiMETTypeOne120+process.hltPFPuppiMHT+process.hltPFPuppiMHT120)
+process.HLT_PFPuppiMETTypeOne140_PFPuppiMHT140 = cms.Path(process.l1tPFPuppiMET220off+process.HLTParticleFlowSequence+process.HLTAK4PFPuppiJetsReconstruction+process.HLTPFPuppiMETReconstruction+process.hltPFPuppiMETTypeOneCorrector+process.hltPFPuppiMETTypeOne+process.hltPFPuppiMETTypeOne140+process.hltPFPuppiMHT+process.hltPFPuppiMHT140)
 
 
 process.HLTObjects = cms.Path(process.HLTParticleFlowSequence+process.HLTAK4PFPuppiJetsReconstruction+process.hltPFPuppiHT+process.hltHtMhtPFPuppiCentralJetsQuadC30MaxEta2p4+process.hltPFPuppiJetForBtagSelectorEta2p4+process.hltPFPuppiJetForBtagEta2p4)
@@ -44781,5 +44781,5 @@ process.simSiStripDigis = cms.EDAlias(
     )
 )
 
-process.schedule = cms.Schedule(*[ process.l1tReconstructionPath, process.L1T_SinglePFPuppiJet230off, process.L1T_PFPuppiHT450off, process.L1T_PFPuppiMET220off, process.HLT_AK4PFPuppiJet500, process.HLT_PFPuppiHT1050, process.HLT_PFPuppiMETTypeOne120_PFPuppiMHT120, process.L1Objects, process.HLTObjects, process.L1_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4_v1, process.L1_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_p71_2p4_v1, process.HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4_v1, process.HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepCSV_2p4_v1, process.HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4_v1, process.HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4_v1, process.HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4_v1, process.HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4_v1, process.MC_JME, process.noFilter_PFDeepCSVPuppi, process.noFilter_PFDeepFlavourPuppi, process.noFilter_PFDeepCSV_path, process.noFilter_PFProba_path, process.noFilter_PFBProba_path, process.noFilter_PFDeepCSVPuppi_path, process.noFilter_PFProbaPuppi_path, process.noFilter_PFBProbaPuppi_path, process.noFilter_PFDeepFlavourPuppi_path ])
+process.schedule = cms.Schedule(*[ process.l1tReconstructionPath, process.L1T_SinglePFPuppiJet230off, process.L1T_PFPuppiHT450off, process.L1T_PFPuppiMET220off, process.HLT_AK4PFPuppiJet520, process.HLT_PFPuppiHT1070, process.HLT_PFPuppiMETTypeOne140_PFPuppiMHT140, process.L1Objects, process.HLTObjects, process.L1_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4_v1, process.L1_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_p71_2p4_v1, process.HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepCSV_2p4_v1, process.HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepCSV_2p4_v1, process.HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepCSV_2p4_v1, process.HLT_PFHT330PT30_QuadPFPuppiJet_75_60_45_40_TriplePFPuppiBTagDeepFlavour_2p4_v1, process.HLT_PFHT200PT30_QuadPFPuppiJet_70_40_30_30_TriplePFPuppiBTagDeepFlavour_2p4_v1, process.HLT_DoublePFPuppiJets128_DoublePFPuppiBTagDeepFlavour_2p4_v1, process.MC_JME, process.noFilter_PFDeepCSVPuppi, process.noFilter_PFDeepFlavourPuppi, process.noFilter_PFDeepCSV_path, process.noFilter_PFProba_path, process.noFilter_PFBProba_path, process.noFilter_PFDeepCSVPuppi_path, process.noFilter_PFProbaPuppi_path, process.noFilter_PFBProbaPuppi_path, process.noFilter_PFDeepFlavourPuppi_path ])
 


### PR DESCRIPTION
#### PR description:

Updates meant to be included in https://github.com/cms-sw/cmssw/pull/32903.

Preliminary HLT thresholds for the Jet/MET trigger paths in the Phase-2 menu (single-jet, HT, and MET+MHT triggers), as presented at the DAQ/HLT Annual Review of January 2021.

#### PR validation:

Checked that the python configuration works (e.g. `edmConfigDump`).