### PR TITLE
fixed a plugin name in cms-sw/cmssw#32903

### DIFF
--- a/HLTrigger/Phase2/python/HLT_75e33/modules/hltPixelClustersMultiplicity_cfi.py
+++ b/HLTrigger/Phase2/python/HLT_75e33/modules/hltPixelClustersMultiplicity_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-hltPixelClustersMultiplicity = cms.EDProducer("SiPixelClusterMultiplicityValueProducer",
+hltPixelClustersMultiplicity = cms.EDProducer("HLTSiPixelClusterMultiplicityValueProducer",
     defaultValue = cms.double(-1.0),
     mightGet = cms.optional.untracked.vstring,
     src = cms.InputTag("siPixelClusters")

--- a/HLTrigger/Phase2/python/HLT_75e33_cfg.py
+++ b/HLTrigger/Phase2/python/HLT_75e33_cfg.py
@@ -10077,7 +10077,7 @@ process.hltPhase2L3OITrackCandidates = cms.EDProducer("CkfTrackCandidateMaker",
 )
 
 
-process.hltPixelClustersMultiplicity = cms.EDProducer("SiPixelClusterMultiplicityValueProducer",
+process.hltPixelClustersMultiplicity = cms.EDProducer("HLTSiPixelClusterMultiplicityValueProducer",
     defaultValue = cms.double(-1.0),
     mightGet = cms.optional.untracked.vstring,
     src = cms.InputTag("siPixelClusters")


### PR DESCRIPTION
#### PR description:

In support of https://github.com/cms-sw/cmssw/pull/32903, this PR includes a fix to the name of a plugin used in the reconstruction of Jets and MET in the present Phase-2 HLT configuration.

The plugin was introduced in https://github.com/cms-sw/cmssw/pull/33205 (not sure what caused the misnaming in https://github.com/cms-sw/cmssw/pull/32903 in the first place).

#### PR validation:

Validated with non-central tools.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A