### PR TITLE
Remove __builtin_assume_aligned compiler hinting as it breaks __restr…

### DIFF
--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -66,8 +66,9 @@ Serialization of Eigen data is not yet supported.
 The template shared by layouts and parameters are:
 - Byte aligment (defaulting to the nVidia GPU cache line size (128 bytes))
 - Alignment enforcement (`relaxed` or `enforced`). When enforced, the alignment will be checked at construction
-  time, and the accesses are done with compiler hinting (using the widely supported `__builtin_assume_aligned`
-  intrinsic).
+  time.~~, and the accesses are done with compiler hinting (using the widely supported `__builtin_assume_aligned`
+  intrinsic).~~ It turned out that hinting `nvcc` for alignement removed the benefit of more important `__restrict__`
+  hinting. The `__builtin_assume_aligned` is hence currently not use.
 
 In addition, the views also provide access parameters:
 - Restrict qualify: add restrict hints to read accesses, so that the compiler knows it can relax accesses to the

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -287,19 +287,19 @@ namespace cms::soa {
 
     SOA_HOST_DEVICE SOA_INLINE Ref operator()() {
       // Ptr type will add the restrict qualifyer if needed
-      Ptr col = alignedCol();
+      Ptr col = col_;
       return col[idx_];
     }
 
     SOA_HOST_DEVICE SOA_INLINE RefToConst operator()() const {
       // PtrToConst type will add the restrict qualifyer if needed
-      PtrToConst col = alignedCol();
+      PtrToConst col = col_();
       return col[idx_];
     }
 
-    SOA_HOST_DEVICE SOA_INLINE Ptr operator&() { return &alignedCol()[idx_]; }
+    SOA_HOST_DEVICE SOA_INLINE Ptr operator&() { return &col_[idx_]; }
 
-    SOA_HOST_DEVICE SOA_INLINE PtrToConst operator&() const { return &alignedCol()[idx_]; }
+    SOA_HOST_DEVICE SOA_INLINE PtrToConst operator&() const { return &col_[idx_]; }
 
     /* This was an attempt to implement the syntax
      *
@@ -318,7 +318,7 @@ namespace cms::soa {
 
     template <typename T2>
     SOA_HOST_DEVICE SOA_INLINE Ref operator=(const T2& v) {
-      return alignedCol()[idx_] = v;
+      return col_[idx_] = v;
     }
     */
 
@@ -327,13 +327,6 @@ namespace cms::soa {
     static constexpr auto valueSize = sizeof(T);
 
   private:
-    SOA_HOST_DEVICE SOA_INLINE Ptr alignedCol() const {
-      if constexpr (ALIGNMENT) {
-        return reinterpret_cast<Ptr>(__builtin_assume_aligned(col_, ALIGNMENT));
-      }
-      return reinterpret_cast<Ptr>(col_);
-    }
-
     size_type idx_;
     T* col_;
   };
@@ -437,11 +430,11 @@ namespace cms::soa {
 
     SOA_HOST_DEVICE SOA_INLINE RefToConst operator()() const {
       // Ptr type will add the restrict qualifyer if needed
-      PtrToConst col = alignedCol();
+      PtrToConst col = col_;
       return col[idx_];
     }
 
-    SOA_HOST_DEVICE SOA_INLINE const T* operator&() const { return &alignedCol()[idx_]; }
+    SOA_HOST_DEVICE SOA_INLINE const T* operator&() const { return &col_[idx_]; }
 
     /* This was an attempt to implement the syntax
      *
@@ -461,13 +454,6 @@ namespace cms::soa {
     static constexpr auto valueSize = sizeof(T);
 
   private:
-    SOA_HOST_DEVICE SOA_INLINE PtrToConst alignedCol() const {
-      if constexpr (ALIGNMENT) {
-        return reinterpret_cast<PtrToConst>(__builtin_assume_aligned(col_, ALIGNMENT));
-      }
-      return reinterpret_cast<PtrToConst>(col_);
-    }
-
     size_type idx_;
     const T* col_;
   };


### PR DESCRIPTION
This PR was tested successfully against CMSSW_12_6_0_pre4. We now have loads via non-coherent cache where expected (i.e. for variables that the kernel does not modify).