### PR TITLE
Add range checking to view-level indexed accessors of SoA.

### DIFF
--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -581,17 +581,6 @@
         throw std::runtime_error("In " #CLASS "::" #CLASS ": unexpected end pointer.");                                \
     }                                                                                                                  \
                                                                                                                        \
-    /* Range checker conditional to the macro _DO_RANGECHECK */                                                        \
-    SOA_HOST_DEVICE SOA_INLINE                                                                                         \
-    void rangeCheck(size_type index) const {                                                                           \
-      if constexpr (_DO_RANGECHECK) {                                                                                  \
-        if (index >= elements_) {                                                                                      \
-          printf("In " #CLASS "::rangeCheck(): index out of range: %zu with elements: %zu\n", index, elements_);       \
-          assert(false);                                                                                               \
-        }                                                                                                              \
-      }                                                                                                                \
-    }                                                                                                                  \
-                                                                                                                       \
     /* Data members */                                                                                                 \
     std::byte* mem_;                                                                                                   \
     size_type elements_;                                                                                               \

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -389,7 +389,11 @@ namespace cms::soa {
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                        \
                  template RestrictQualifier<restrictQualify>::ParamReturnType                                          \
   LOCAL_NAME(size_type index) {                                                                                        \
-    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                   \
+    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                                 \
+      if (index >= base_type::elements_)                                                                               \
+        SOA_THROW_OUT_OF_RANGE("Out of range index in mutable " #LOCAL_NAME "(size_type index)")                       \
+    }                                                                                                                  \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
             cms::soa::SoAAccessType::mutableAccess>::template Alignment<conditionalAlignment>::                        \
                 template RestrictQualifier<restrictQualify>(const_cast_SoAParametersImpl(                              \
@@ -423,7 +427,11 @@ namespace cms::soa {
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                          \
                 template RestrictQualifier<restrictQualify>::ParamReturnType                                           \
   LOCAL_NAME(size_type index) const {                                                                                  \
-    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                   \
+    if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                                 \
+      if (index >= elements_)                                                                                          \
+        SOA_THROW_OUT_OF_RANGE("Out of range index in const " #LOCAL_NAME "(size_type index)")                         \
+    }                                                                                                                  \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
         template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
             cms::soa::SoAAccessType::constAccess>::template Alignment<conditionalAlignment>::                          \
                 template RestrictQualifier<restrictQualify>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))(index);             \

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
@@ -101,7 +101,7 @@ using RangeCheckingHostDeviceView =
 
 // We expect to just run one thread.
 __global__ void rangeCheckKernel(RangeCheckingHostDeviceView soa) {
-  printf("About to fail range-check in CUDA thread: %d\n", threadIdx.x);
+  printf("About to fail range-check (operator[]) in CUDA thread: %d\n", threadIdx.x);
   [[maybe_unused]] auto si = soa[soa.metadata().size()];
   printf("Fail: range-check failure should have stopped the kernel.\n");
 }
@@ -250,10 +250,23 @@ int main(void) {
         soa1viewRangeChecking(h_soahdLayout);
     // This should throw an exception
     [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size()];
-    std::cout << "Fail: expected range-check exception not caught on the host." << std::endl;
+    std::cout << "Fail: expected range-check exception (operator[]) not caught on the host." << std::endl;
     assert(false);
   } catch (const std::out_of_range&) {
-    std::cout << "Pass: expected range-check exception successfully caught on the host." << std::endl;
+    std::cout << "Pass: expected range-check exception (operator[]) successfully caught on the host." << std::endl;
+  }
+
+  try {
+    // Get a view like the default, except for range checking
+    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::enabled>
+        soa1viewRangeChecking(h_soahdLayout);
+    // This should throw an exception
+    [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size()];
+    std::cout << "Fail: expected range-check exception (view-level index access) not caught on the host." << std::endl;
+    assert(false);
+  } catch (const std::out_of_range&) {
+    std::cout << "Pass: expected range-check exception (view-level index access) successfully caught on the host."
+              << std::endl;
   }
 
   // Validation of range checking in a kernel

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -50,6 +50,30 @@ namespace {
   }
 }  // namespace
 
+namespace {
+  template <typename T>
+  void assertAddresses(T& view) {
+    assert(view.metadata().addressOf_x() == view.x());
+    assert(view.metadata().addressOf_x() == &view.x(0));
+    assert(view.metadata().addressOf_x() == &view[0].x());
+    assert(view.metadata().addressOf_y() == view.y());
+    assert(view.metadata().addressOf_y() == &view.y(0));
+    assert(view.metadata().addressOf_y() == &view[0].y());
+    assert(view.metadata().addressOf_z() == view.z());
+    assert(view.metadata().addressOf_z() == &view.z(0));
+    assert(view.metadata().addressOf_z() == &view[0].z());
+    assert(view.metadata().addressOf_id() == view.id());
+    assert(view.metadata().addressOf_id() == &view.id(0));
+    assert(view.metadata().addressOf_id() == &view[0].id());
+    assert(view.metadata().addressOf_m() == view.m());
+    assert(view.metadata().addressOf_m() == &view.m(0).coeffRef(0, 0));
+    assert(view.metadata().addressOf_m() == &view[0].m().coeffRef(0, 0));
+    assert(view.metadata().addressOf_r() == &view.r());
+    //assert(view.metadata().addressOf_r() == &view.r(0));                  // cannot access a scalar with an index
+    //assert(view.metadata().addressOf_r() == &view[0].r());                // cannot access a scalar via a SoA row-like accessor
+  }
+}  // namespace
+
 class TestAlpakaAnalyzer : public edm::stream::EDAnalyzer<> {
 public:
   TestAlpakaAnalyzer(edm::ParameterSet const& config)
@@ -58,6 +82,8 @@ public:
   void analyze(edm::Event const& event, edm::EventSetup const&) override {
     portabletest::TestHostCollection const& product = event.get(token_);
     auto const& view = product.const_view();
+    auto& mview = product.view();
+    auto const& cmview = product.view();
 
     {
       edm::LogInfo msg("TestAlpakaAnalyzer");
@@ -88,24 +114,9 @@ public:
                  reinterpret_cast<intptr_t>(view.metadata().addressOf_r());
     }
 
-    assert(view.metadata().addressOf_x() == view.x());
-    assert(view.metadata().addressOf_x() == &view.x(0));
-    assert(view.metadata().addressOf_x() == &view[0].x());
-    assert(view.metadata().addressOf_y() == view.y());
-    assert(view.metadata().addressOf_y() == &view.y(0));
-    assert(view.metadata().addressOf_y() == &view[0].y());
-    assert(view.metadata().addressOf_z() == view.z());
-    assert(view.metadata().addressOf_z() == &view.z(0));
-    assert(view.metadata().addressOf_z() == &view[0].z());
-    assert(view.metadata().addressOf_id() == view.id());
-    assert(view.metadata().addressOf_id() == &view.id(0));
-    assert(view.metadata().addressOf_id() == &view[0].id());
-    assert(view.metadata().addressOf_m() == view.m());
-    assert(view.metadata().addressOf_m() == &view.m(0).coeffRef(0, 0));
-    assert(view.metadata().addressOf_m() == &view[0].m().coeffRef(0, 0));
-    assert(view.metadata().addressOf_r() == &view.r());
-    //assert(view.metadata().addressOf_r() == &view.r(0));                  // cannot access a scalar with an index
-    //assert(view.metadata().addressOf_r() == &view[0].r());                // cannot access a scalar via a SoA row-like accessor
+    assertAddresses(view);
+    assertAddresses(mview);
+    assertAddresses(cmview);
 
     const portabletest::Matrix matrix{{1, 2, 3, 4, 5, 6}, {2, 4, 6, 8, 10, 12}, {3, 6, 9, 12, 15, 18}};
     assert(view.r() == 1.);


### PR DESCRIPTION
Validated with `HeterogeneousCore/AlpakaTest/test/testHeterogeneousCoreAlpakaTestWriteRead.sh` and `test/el8_amd64_gcc10/SoALayoutAndView_t`. Added validation for const_view, const (mutable) view and bare mutable view.